### PR TITLE
moved ja-che to Parietal-INRIA

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ Or if you want the latest version available (for example to contribute to
 the development of this project:
 
 ```
-pip install -U git+https://github.com/ja-che/hidimstat.git
+pip install -U git+https://github.com/Parietal-INRIA/hidimstat.git
 ```
 
 or
 
 ```bash
-git clone https://github.com/ja-che/hidimstat.git
+git clone https://github.com/Parietal-INRIA/hidimstat.git
 cd hidimstat
 pip install -e .
 ```
@@ -43,7 +43,7 @@ is also needed to install `pytest`.
 
 ## Documentation & Examples
 
-All the documentation of HiDimStat is available at https://ja-che.github.io/hidimstat/.
+All the documentation of HiDimStat is available at https://Parietal-INRIA.github.io/hidimstat/.
 
 As of now in the `examples` folder there are three Python scripts that
 illustrate how to use the main HiDimStat functions.
@@ -64,7 +64,7 @@ python plot_2D_simulation_example.py
 
 The algorithms developed in this package have been detailed in several
 conference/journal articles that can be downloaded at
-https://ja-che.github.io/research.html.
+https://Parietal-INRIA.github.io/research.html.
 
 #### Main references:
 
@@ -133,8 +133,8 @@ Union’s Horizon 2020 research and innovation program
 (Grant Agreement No. 945539, Human Brain Project SGA3).
 
 
-[TravisCI]: https://travis-ci.com/ja-che/hidimstat.svg?branch=main "travisCI status"
-[travis]: https://travis-ci.com/ja-che/hidimstat
+[TravisCI]: https://travis-ci.com/Parietal-INRIA/hidimstat.svg?branch=main "travisCI status"
+[travis]: https://travis-ci.com/Parietal-INRIA/hidimstat
 
-[CodeCov]: https://codecov.io/gh/ja-che/hidimstat/branch/main/graph/badge.svg "CodeCov status"
-[cov]: https://codecov.io/gh/ja-che/hidimstat
+[CodeCov]: https://codecov.io/gh/Parietal-INRIA/hidimstat/branch/main/graph/badge.svg "CodeCov status"
+[cov]: https://codecov.io/gh/Parietal-INRIA/hidimstat

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -122,7 +122,7 @@ html_theme_options = {
     'navbar_links': [
         ("Examples", "auto_examples/index"),
         ("API", "api"),
-        ("GitHub", "https://github.com/ja-che/hidimstat", True)
+        ("GitHub", "https://github.com/Parietal-INRIA/hidimstat", True)
     ],
     'bootswatch_theme': "flatly",
     'bootstrap_version': "3",

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -23,7 +23,7 @@ run the following from terminal::
 Or if you want the latest version available (for example to contribute to
 the development of this project)::
 
-  git clone https://github.com/ja-che/hidimstat.git
+  git clone https://github.com/Parietal-INRIA/hidimstat.git
   cd hidimstat
   pip install -e .
 
@@ -81,7 +81,7 @@ References
 
 The algorithms developed in this package have been detailed in several
 conference/journal articles that can be downloaded at
-`https://ja-che.github.io/ <https://ja-che.github.io/research.html>`_.
+`https://Parietal-INRIA.github.io/ <https://Parietal-INRIA.github.io/research.html>`_.
 
 Main references
 ~~~~~~~~~~~~~~~
@@ -146,11 +146,11 @@ For Knockoffs Inference:
   knockoffs for high dimensional controlled variable selection. Journal of the
   Royal Statistical Society Series B, 80(3), 551-577.
 
-.. |Build Status| image:: https://travis-ci.com/ja-che/hidimstat.svg?branch=main
-   :target: https://codecov.io/gh/ja-che/hidimstat
+.. |Build Status| image:: https://travis-ci.com/Parietal-INRIA/hidimstat.svg?branch=main
+   :target: https://codecov.io/gh/Parietal-INRIA/hidimstat
 
-.. |codecov| image:: https://codecov.io/gh/ja-che/hidimstat/branch/main/graph/badge.svg
-   :target: https://codecov.io/gh/ja-che/hidimstat
+.. |codecov| image:: https://codecov.io/gh/Parietal-INRIA/hidimstat/branch/main/graph/badge.svg
+   :target: https://codecov.io/gh/Parietal-INRIA/hidimstat
 
 
 API

--- a/examples/plot_2D_simulation_example.py
+++ b/examples/plot_2D_simulation_example.py
@@ -236,7 +236,7 @@ beta_extended = weight_map_2D_extended(shape, roi_size, delta)
 # infernece method that does not leverage the data structure. This method
 # was introduced by Javanmard, A. et al. (2014), Zhang, C. H. et al. (2014)
 # and Van de Geer, S. et al.. (2014) (full references are available at
-# https://ja-che.github.io/hidimstat/).
+# https://Parietal-INRIA.github.io/hidimstat/).
 # and referred to as Desparsified Lasso.
 
 # compute desparsified lasso

--- a/setup.py
+++ b/setup.py
@@ -8,10 +8,10 @@ from setuptools import find_packages
 PKG = 'hidimstat'
 DESCRIPTION = "High-dimensional statistical inference tools for Python"
 LONG_DESCRIPTION = open('README.md').read()
-MAINTAINER = 'Chevalier (ja-che) and Nguyen (tbng)'
-MAINTAINER_EMAIL = 'jerome-alexis_chevalier@hotmail.fr'
-URL = 'https://github.com/ja-che/hidimstat'
-DOWNLOAD_URL = 'https://github.com/ja-che/hidimstat'
+MAINTAINER = 'Chevalier (ja-che), Nguyen (tbng), Alexandre Blain (alexblnn), Ahmad Chamma and Bertrand Thirion (bthirion)'
+MAINTAINER_EMAIL = 'bertrand.thirion@inria.fr'
+URL = 'https://github.com/Parietal-INRIA/hidimstat'
+DOWNLOAD_URL = 'https://github.com/Parietal-INRIA/hidimstat'
 LICENSE = 'BSD'
 
 


### PR DESCRIPTION
This branch aims at rooting all the builds on Parietal-INRIA rather than ja-che for long terme support.